### PR TITLE
Send filename in second param of svgo.optimize for plugin use

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function svg(options) {
     name: 'svgo',
     transform: (code, id) => {
       if (id.endsWith('.svg')) {
-        return svgo.optimize(code).then(result => ({
+        return svgo.optimize(code, { path: id }).then(result => ({
           map: { mappings: '' },
           code: 'export default ' + JSON.stringify(result.data)
         }))


### PR DESCRIPTION
svgo.optimize accepts a second parameter, which is passed to plugins. rollup-plugin-svgo currently doesn't pass this parameter, which breaks svgo opts that are expecting it.

For example, consider this usage of the prefixIds plugin:

```js
const prefixes = {};

module.exports = {
  plugins: [
    ...
    {
      prefixIds: {
        prefix(_el, filepath) {
          const { path } = filepath;
          if (!prefixes[path]) {
            prefixes[path] = Object.keys(prefixes).length;
          }
          return `svg-${prefixes[path]}`;
        },
      },
    },
    ...
  ],
};

```
This configuration prefixes IDs to avoid collisions when multiple SVG files are processed to be displayed at the same time. The configuration provided works with the [webpack svgo loader](https://github.com/rpominov/svgo-loader) because [they pass the filename](https://github.com/rpominov/svgo-loader/blob/e4d6f3e256e741c1b57c386da916d8bf148644b7/index.js#L54). It breaks with rollup-plugin-svgo.

This PR brings rollup-plugin-svgo into parity with the webpack loader and prevents breakage when plugins/configurations expect this information to be present.